### PR TITLE
Check for VS 2015: it doesn`t support stdint.h

### DIFF
--- a/include/rapidjson/rapidjson.h
+++ b/include/rapidjson/rapidjson.h
@@ -159,7 +159,7 @@
 */
 #ifndef RAPIDJSON_NO_INT64DEFINE
 //!@cond RAPIDJSON_HIDDEN_FROM_DOXYGEN
-#if defined(_MSC_VER) && (_MSC_VER < 1800)	// Visual Studio 2013
+#if defined(_MSC_VER) && (_MSC_VER < 1900)	// Visual Studio 2015
 #include "msinttypes/stdint.h"
 #include "msinttypes/inttypes.h"
 #else


### PR DESCRIPTION
Visual Studio 2015 doesn't support stdint.h yet, so we should include msinttypes/stdint.h instead of stdint.h
